### PR TITLE
fix(python) : specifying protobuf version

### DIFF
--- a/python/fds.protobuf.stach.v2/setup.py
+++ b/python/fds.protobuf.stach.v2/setup.py
@@ -7,6 +7,6 @@ setup(name='fds.protobuf.stach.v2',
       author='analytics-reporting',
       author_email='analytics.api.support@factset.com',
       license='Apache License 2.0',
-      install_requires=["protobuf<4.0.0"],
+      install_requires=["protobuf>=3.12.0,<4.0.0"],
       packages=find_packages(),
       zip_safe=False)

--- a/python/fds.protobuf.stach.v2/setup.py
+++ b/python/fds.protobuf.stach.v2/setup.py
@@ -7,6 +7,6 @@ setup(name='fds.protobuf.stach.v2',
       author='analytics-reporting',
       author_email='analytics.api.support@factset.com',
       license='Apache License 2.0',
-      install_requires=["protobuf>=3.12.0,<4.0.0"],
+      install_requires=["protobuf>=3.12.3,<4.0.0"],
       packages=find_packages(),
       zip_safe=False)

--- a/python/fds.protobuf.stach.v2/setup.py
+++ b/python/fds.protobuf.stach.v2/setup.py
@@ -7,6 +7,6 @@ setup(name='fds.protobuf.stach.v2',
       author='analytics-reporting',
       author_email='analytics.api.support@factset.com',
       license='Apache License 2.0',
-      install_requires=["protobuf"],
+      install_requires=["protobuf<4.0.0"],
       packages=find_packages(),
       zip_safe=False)

--- a/python/fds.protobuf.stach.v2/setup.py
+++ b/python/fds.protobuf.stach.v2/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='fds.protobuf.stach.v2',
-      version='1.0.1',
+      version='1.0.2',
       description='Stach library in python',
       url='',
       author='analytics-reporting',


### PR DESCRIPTION
This change specifies the protobuf version as a limit so that when users have older version of protobuf and trying to install stachschema sdk, the installation will try to update protobuf to the latest version