### PR TITLE
feat(python): support multiple versions

### DIFF
--- a/.github/workflows/release-older-version-sdks.yml
+++ b/.github/workflows/release-older-version-sdks.yml
@@ -6,12 +6,16 @@ env:
   MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD_2024OCT }}
   MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
   JAVA_SDK_LOCATION_v1: "java/v1" 
-  JAVA_SDK_LOCATION_v2: "java/v2" 
+  JAVA_SDK_LOCATION_v2: "java/v2"
+  PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  PYTHON_SDK_LOCATION_v2: "python/fds.protobuf.stach.v2"
+
 on:
   workflow_dispatch:
     inputs:
       SDKs:
-        description: 'Which SDK to release? Options are "java-v1" and "java-v2"'
+        description: 'Which SDK to release? Options are "java-v1", "java-v2" and "python-v2"'
         required: true
         default: all
 
@@ -69,3 +73,30 @@ jobs:
       run: |
         cd ${{ env.JAVA_SDK_LOCATION_v2 }}
         mvn -Psign-artifacts verify deploy
+
+  python-v2:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' 
+      && github.event.inputs.SDKs == 'python-v2'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish to PyPI
+      env:
+        TWINE_USERNAME: ${{ env.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ env.PYPI_PASSWORD }}
+      run: |
+        cd ${{ env.PYTHON_SDK_LOCATION_v2 }}
+        python setup.py sdist bdist_wheel
+        twine upload dist/* --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules/
 js/node_modules/
 python/fds.protobuf.stach/dist/*.*
 python/fds.protobuf.stach/fds.protobuf.stach.egg-info
+python/fds.protobuf.stach.v2/dist/*.*
+python/fds.protobuf.stach.v2/fds.protobuf.stach.v2.egg-info
+python/fds.protobuf.stach.v3/dist/*.*
+python/fds.protobuf.stach.v3/fds.protobuf.stach.v3.egg-info
 r/*.tar.gz
 r/.RData
 r/.Rhistory

--- a/python/CI/generate-sdk.sh
+++ b/python/CI/generate-sdk.sh
@@ -1,20 +1,47 @@
 #!/bin/bash
 set -e
+# --- Add these variables ---
+GIT_REPO_URL="https://github.com/factset/stachschema.git"
+LOCAL_SCHEMA_PATH="./tmp"
+BRANCH_NAME="feat/sdks/support-versions"
 
-SCHEMA_PATH=/schema # Location of Protobuf schema
-BASE_PATH=/python/fds.protobuf.stach.v3 # Base location of Python generated classes
-PACKAGE_PATH=fds/protobuf/stach/v3
+# Clone or update the repo
+if [ -d "$LOCAL_SCHEMA_PATH/.git" ]; then
+    git -C "$LOCAL_SCHEMA_PATH" pull origin "$BRANCH_NAME"
+    git -C "$LOCAL_SCHEMA_PATH" checkout "$BRANCH_NAME"
+else
+    if [ -d "$LOCAL_SCHEMA_PATH" ]; then
+        echo "Directory $LOCAL_SCHEMA_PATH exists but is not a git repo. Removing..."
+        rm -rf "$LOCAL_SCHEMA_PATH"
+    fi
+    git clone -b "$BRANCH_NAME" "$GIT_REPO_URL" "$LOCAL_SCHEMA_PATH"
+fi
 
-rm -f $BASE_PATH/$PACKAGE_PATH/**/*_pb2.py
+SCHEMA_PATH="$LOCAL_SCHEMA_PATH/proto" # Location of Protobuf schema
+BASE_PATH_V3=../fds.protobuf.stach.v3 # Base location of Python generated classes
+BASE_PATH_V2=../fds.protobuf.stach.v2 # Base location of Python generated classes
+PACKAGE_PATH_V3=v3/fds/protobuf/stach/v3
+PACKAGE_PATH_V2=v2/fds/protobuf/stach/v2
 
-echo Removed old generated code
+# rm -f $BASE_PATH_V2/$PACKAGE_PATH_V2/**/*_pb2.py
+# rm -f $BASE_PATH_V3/$PACKAGE_PATH_V3/**/*_pb2.py
 
-PROTOFILES=$(find $SCHEMA_PATH/$PACKAGE_PATH -iname "*.proto")
-protoc --proto_path $SCHEMA_PATH --python_out $BASE_PATH $PROTOFILES
+# echo Removed old generated code
+mkdir -p "$BASE_PATH_V3"
+mkdir -p "$BASE_PATH_V2"
 
-for f in $(find $BASE_PATH/fds/protobuf/stach/v3 -type d -maxdepth 10); do
-	cd "$f"
-	touch __init__.py
+PROTOFILES=$(find $SCHEMA_PATH/$PACKAGE_PATH_V3 -iname "*.proto")
+protoc --proto_path $SCHEMA_PATH/v3 --python_out $BASE_PATH_V3 $PROTOFILES
+
+for f in $(find $BASE_PATH_V3/fds/protobuf/stach/v3 -type d -maxdepth 10); do
+	touch "$f/__init__.py"
+done;
+
+PROTOFILES=$(find $SCHEMA_PATH/$PACKAGE_PATH_V2 -iname "*.proto")
+protoc --proto_path $SCHEMA_PATH/v2 --python_out $BASE_PATH_V2 $PROTOFILES
+
+for f in $(find $BASE_PATH_V2/fds/protobuf/stach/v2 -type d -maxdepth 10); do
+	touch "$f/__init__.py"
 done;
 
 echo Produced new generated code

--- a/python/CI/generate-sdk.sh
+++ b/python/CI/generate-sdk.sh
@@ -23,10 +23,10 @@ BASE_PATH_V2=../fds.protobuf.stach.v2 # Base location of Python generated classe
 PACKAGE_PATH_V3=v3/fds/protobuf/stach/v3
 PACKAGE_PATH_V2=v2/fds/protobuf/stach/v2
 
-# rm -f $BASE_PATH_V2/$PACKAGE_PATH_V2/**/*_pb2.py
-# rm -f $BASE_PATH_V3/$PACKAGE_PATH_V3/**/*_pb2.py
-
 # echo Removed old generated code
+rm -f $BASE_PATH_V2/$PACKAGE_PATH_V2/**/*_pb2.py
+rm -f $BASE_PATH_V3/$PACKAGE_PATH_V3/**/*_pb2.py
+
 mkdir -p "$BASE_PATH_V3"
 mkdir -p "$BASE_PATH_V2"
 

--- a/python/fds.protobuf.stach.v2/setup.py
+++ b/python/fds.protobuf.stach.v2/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
-setup(name='fds.protobuf.stach.v3',
-      version='1.0.1',
+setup(name='fds.protobuf.stach.v2',
+      version='1.0.3',
       description='Stach library in python',
       url='',
       author='analytics-reporting',


### PR DESCRIPTION
Updated generate-sdk script for python to generate code for both stach v2 and v3 and also added setup.py for both versions with patch version upgraded, as I've updated the condition for required protobuf version.
Also updated the release-older-version-sdks script to include python stach v2 as an option.